### PR TITLE
Edited lru_cache decorator of pfsspy.Output.bg to conserve memory.

### DIFF
--- a/pfsspy/__init__.py
+++ b/pfsspy/__init__.py
@@ -410,7 +410,7 @@ class Output:
         return br, -bs, bp
 
     @property
-    @functools.lru_cache()
+    @functools.lru_cache(maxsize=1)
     def bg(self):
         """
         B as a (weighted) averaged on grid points.


### PR DESCRIPTION
Addressing issue #148 :

The ` functools.lru_cache`  function is used as a decorator for the` pfspy.Output.bg` method to cache the `bg` value in memory. For a standard pfsspy run this is quite a large 3D numpy array.

By default [functools.lru_cache](https://docs.python.org/3/library/functools.html#functools.lru_cache), for a given `pfsspy.Output `object `lru_cache` will cache the most recent 128 calls of `bg` in distinct places in memory. For code which repeatedly accesses bg from the same output, memory usage can therefore climb each call. 

By changing it's maxsize argument to `maxsize=1`, only the most recent call is cached and Output.bg can be repeatedly accessed without memory build up.