### PR TITLE
Added ADAPTMap class in pfsspy.map

### DIFF
--- a/pfsspy/map.py
+++ b/pfsspy/map.py
@@ -27,9 +27,11 @@ class GongSynopticMap(sunpy.map.GenericMap):
 class ADAPTMap(sunpy.map.GenericMap):
     def __init__(self, data, header, **kwargs):
         header['date-obs'] = header['maptime']
-        header['t_obs'] = header['maptime']
-        header['ctype1'] = 'CRLN-CEA'
-        header['ctype2'] = 'CRLT-CEA'
+        if not ((header['cunit2'] == 'deg') & 
+                (header['naxis2']*header['cdelt2'] == 180)) :
+            raise AssertionError("Latitude metadata doesn't add to 180deg")
+        header['ctype1'] = 'CRLN'
+        header['ctype2'] = 'CRLT'
         super().__init__(data, header, **kwargs)
 
     @classmethod

--- a/pfsspy/map.py
+++ b/pfsspy/map.py
@@ -22,3 +22,18 @@ class GongSynopticMap(sunpy.map.GenericMap):
         """Determines if header corresponds to an GONG map."""
         return (str(header.get('TELESCOP', '')).endswith('GONG') and
                 str(header.get('CTYPE1', '').startswith('CRLN')))
+
+
+class ADAPTMap(sunpy.map.GenericMap):
+    def __init__(self, data, header, **kwargs):
+        header['date-obs'] = header['maptime']
+        header['t_obs'] = header['maptime']
+        header['ctype1'] = 'CRLN-CEA'
+        header['ctype2'] = 'CRLT-CEA'
+        super().__init__(data, header, **kwargs)
+
+    @classmethod
+    def is_datasource_for(cls, data, header, **kwargs):
+        """Determines if header corresponds to an ADAPT map."""
+        return header.get('model') == 'ADAPT'
+

--- a/pfsspy/map.py
+++ b/pfsspy/map.py
@@ -30,8 +30,8 @@ class ADAPTMap(sunpy.map.GenericMap):
         if not ((header['cunit2'] == 'deg') & 
                 (header['naxis2']*header['cdelt2'] == 180)) :
             raise AssertionError("Latitude metadata doesn't add to 180deg")
-        header['ctype1'] = 'CRLN'
-        header['ctype2'] = 'CRLT'
+        header['ctype1'] = 'CRLN-CAR'
+        header['ctype2'] = 'CRLT-CAR'
         super().__init__(data, header, **kwargs)
 
     @classmethod

--- a/pfsspy/tests/test_map.py
+++ b/pfsspy/tests/test_map.py
@@ -25,3 +25,10 @@ def gong_map():
 def test_gong_source(gong_map):
     m = sunpy.map.Map(gong_map)
     assert isinstance(m, pfsspy.map.GongSynopticMap)
+
+def test_adapt_map():
+    import sunpy.io
+    adapt_fits = sunpy.io.fits.read("ftp://gong.nso.edu/adapt/maps/gong/2020/adapt40311_03k012_202001010000_i00005600n1.fts.gz")
+    for map_slice in adapt_fits[0].data :
+        m = sunpy.map.Map((map_slice,adapt_fits[0].header))
+        assert isinstance(m, pfsspy.map.ADAPTMap)

--- a/pfsspy/tests/test_map.py
+++ b/pfsspy/tests/test_map.py
@@ -26,9 +26,25 @@ def test_gong_source(gong_map):
     m = sunpy.map.Map(gong_map)
     assert isinstance(m, pfsspy.map.GongSynopticMap)
 
-def test_adapt_map():
+
+@pytest.fixture
+def adapt_map():
+    import urllib.request
+    urllib.request.urlretrieve(
+        "https://gong.nso.edu/adapt/maps/gong/2020/adapt40311_03k012_202001010000_i00005600n1.fts.gz",
+        "adapt20200101.fts.gz")
+
+    if not os.path.exists("adapt20200101.fts"):
+        import gzip
+        with gzip.open('adapt20200101.fts.gz', 'rb') as f:
+            with open('adapt20200101.fts', 'wb') as g:
+                g.write(f.read())
+
+    return 'adapt20200101.fts'
+
+def test_adapt_map(adapt_map):
     import sunpy.io
-    adapt_fits = sunpy.io.fits.read("ftp://gong.nso.edu/adapt/maps/gong/2020/adapt40311_03k012_202001010000_i00005600n1.fts.gz")
+    adapt_fits = sunpy.io.fits.read(adapt_map)
     for map_slice in adapt_fits[0].data :
         m = sunpy.map.Map((map_slice,adapt_fits[0].header))
         assert isinstance(m, pfsspy.map.ADAPTMap)


### PR DESCRIPTION
Referencing #166  . This commit adds an ADAPTMap custom class to pfsspy.map. This checks the map header has the field ("model" : 'ADAPT'), and if so, corrects the coordinate system and  date-obs meta data. 

If a standard adapt fits file with a 3d datacube is passed to this class, a warning that the data is 3D is raised and the first realization is sliced out to create the map. A preprocessng step to produce a MapSequence of ADAPT maps will be written up as an example (see again #166)