### PR TITLE
Add code of conduct text

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,57 @@
+pfsspy is an SunPy affiliated package, and folows the SunPy code of conduct, shown below.
+
+Code of Conduct
+===============
+
+The SunPy community is made up of members from around the globe with a diverse set of skills, personalities, and experiences.
+It is through these differences that our community experiences success and continued growth.
+We expect everyone in our community to follow these guidelines when interacting with others both inside and outside of our community.
+Our goal is to keep ours a positive, inclusive, successful, and growing community.
+
+A member of SunPy is:
+
+Open
+----
+
+Members of the community are open to collaboration, whether on patches, reporting issues, asking for help or otherwise.
+We welcome those interested in joining the community, and realise that including people with a variety of opinions and backgrounds will only serve to enrich our community.
+
+We are accepting of all who wish to take part in our activities, fostering an environment where anyone can participate and everyone can make a difference, ensuring that all participants are heard and feel confident that they can freely express their opinions.
+
+Considerate
+-----------
+
+Members of the community are considerate of their peers -- other developers, users, etc.
+We are thoughtful when addressing the efforts of others, keeping in mind that often the labour was completed simply for the good of the community.
+We are attentive in our communications, whether in person or online, and we're tactful when approaching differing views.
+
+We recognize the work made by everyone and ensure the proper acknowledgement/citation of original authors at all times.
+As authors, we pledge to be explicit about how we want our own work to be cited or acknowledged.
+
+Respectful
+----------
+
+Members of the community are respectful.
+We are respectful of others, their positions, their skills, their commitments, and their efforts.
+We are respectful of the volunteer and professional efforts within the community.
+We are respectful of the processes set forth in the community, and we work within them (paying particular attention to those new to the community).
+
+When we disagree, we are courteous in raising our issues.
+We provide a harassment- and bullying-free environment, regardless of sex, sexual orientation, gender identity, disability, physical appearance, body size, race, nationality, ethnicity, and religion.
+In particular, sexual language and imagery, sexist, racist, or otherwise exclusionary jokes are not appropriate.
+We will treat those outside our community with the same respect as people within our community.
+
+Overall, we are good to each other and apply this code of conduct to all community situations online and offline, including mailing lists, forums, social media, conferences, meetings, associated social events, and one-to-one interactions.
+
+We pledge to help the entire community follow the code of conduct, and to not remain silent when we see violations of the code of conduct.
+We will take action when members of our community violate this code such as contacting <confidential@sunpy.org> (all emails sent to this address will be treated with the strictest confidence) or talking privately with the person.
+
+Parts of this code of conduct have been adapted from the [astropy](http://www.astropy.org/code_of_conduct.html) and the [Python Software Fundation](https://www.python.org/psf/codeofconduct/) codes of conduct.
+
+------------------------------------------------------------------------
+
+License
+-------
+
+The SunPy Community Code of Conduct is licensed under a Creative Commons Attribution 4.0 International License.
+We encourage other communities related to ours to use or adapt this code as they see fit.

--- a/README.md
+++ b/README.md
@@ -10,4 +10,4 @@ Potential Field Source Surface model package for Python. This package is based o
 
 Code of conduct
 ---------------
-This is a community package; please follow the [SunPy code of conduct](https://docs.sunpy.org/en/latest/code_of_conduct.html) when interacting with others within the pfsspy community.
+This is a community package, which has adopted the SunPy code of conduct. Please follow the [code of conduct](CODE_OF_CONDUCT.md) when interacting with others within the pfsspy community.


### PR DESCRIPTION
This adds a permanent code of conduct file, to prevent links from breaking. xref https://github.com/dstansby/pfsspy/issues/239