### PR TITLE
Suggestion: use 'raise from' to handle exception

### DIFF
--- a/pfsspy/tracing.py
+++ b/pfsspy/tracing.py
@@ -96,8 +96,7 @@ class FortranTracer(Tracer):
         except ModuleNotFoundError as e:
             raise RuntimeError(
                 'Using FortranTracer requires the streamtracer module, '
-                'but streamtracer could not be loaded '
-                f'with the following error:\n{e}')
+                'but streamtracer could not be loaded') from e
         self.max_steps = max_steps
         self.step_size = step_size
         self.tracer = StreamTracer(max_steps, step_size)


### PR DESCRIPTION
This PR would make the error message look like:
```
Traceback (most recent call last):
  File "/home/matthieu/pro/github/pfsspy/pfsspy/tracing.py", line 95, in __init__
    from streamtracer import StreamTracer
ModuleNotFoundError: No module named 'streamtracer'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "examples/using_pfsspy/open_closed_map.py", line 71, in <module>
    tracer = tracing.FortranTracer(max_steps=2000)
  File "/home/matthieu/pro/github/pfsspy/pfsspy/tracing.py", line 97, in __init__
    raise RuntimeError(
RuntimeError: Using FortranTracer requires the streamtracer module, but streamtracer could not be loaded
```

instead of

```
Traceback (most recent call last):
  File "/home/matthieu/pro/github/pfsspy/pfsspy/tracing.py", line 95, in __init__
    from streamtracer import StreamTracer
ModuleNotFoundError: No module named 'streamtracer'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "examples/using_pfsspy/open_closed_map.py", line 71, in <module>
    tracer = tracing.FortranTracer(max_steps=2000)
  File "/home/matthieu/pro/github/pfsspy/pfsspy/tracing.py", line 97, in __init__
    raise RuntimeError(
RuntimeError: Using FortranTracer requires the streamtracer module, but streamtracer could not be loaded with the following error:
No module named 'streamtracer'
```
