### PR TITLE
Add functionality for a custom outer boundary condition on `br`

### DIFF
--- a/pfsspy/input.py
+++ b/pfsspy/input.py
@@ -22,6 +22,8 @@ class Input:
         on.
     rss : float
         Radius of the source surface, as a fraction of the solar radius.
+    brout : string
+        Boundary condition at the outer surface.
 
     Notes
     -----
@@ -29,7 +31,7 @@ class Input:
     :math:`s = \cos (\theta)`. See `pfsspy.grid` for more
     information on the coordinate system.
     """
-    def __init__(self, br, nr, rss):
+    def __init__(self, br, nr, rss, brout="radial"):
         if not isinstance(br, sunpy.map.GenericMap):
             raise ValueError('br must be a sunpy Map')
         if np.any(~np.isfinite(br.data)):
@@ -43,6 +45,7 @@ class Input:
         self._map_in = copy.deepcopy(br)
         self.dtime = self.map.date
         self.br = self.map.data
+        self.brout = brout
 
         # Force some nice defaults
         self._map_in.plot_settings['cmap'] = 'RdBu'

--- a/pfsspy/input.py
+++ b/pfsspy/input.py
@@ -31,7 +31,7 @@ class Input:
     :math:`s = \cos (\theta)`. See `pfsspy.grid` for more
     information on the coordinate system.
     """
-    def __init__(self, br, nr, rss, brout="radial", br1=[]):
+    def __init__(self, br, nr, rss, brout="radial", br1=None):
         if not isinstance(br, sunpy.map.GenericMap):
             raise ValueError('br must be a sunpy Map')
         if np.any(~np.isfinite(br.data)):

--- a/pfsspy/input.py
+++ b/pfsspy/input.py
@@ -22,8 +22,8 @@ class Input:
         on.
     rss : float
         Radius of the source surface, as a fraction of the solar radius.
-    brout : string
-        Boundary condition at the outer surface.
+    br_outer : sunpy.map.GenericMap, String
+        Boundary condition of radial magnetic field at the outer surface.
 
     Notes
     -----
@@ -31,7 +31,7 @@ class Input:
     :math:`s = \cos (\theta)`. See `pfsspy.grid` for more
     information on the coordinate system.
     """
-    def __init__(self, br, nr, rss, brout="radial", br1=None):
+    def __init__(self, br, nr, rss, br_outer="radial"):
         if not isinstance(br, sunpy.map.GenericMap):
             raise ValueError('br must be a sunpy Map')
         if np.any(~np.isfinite(br.data)):
@@ -45,8 +45,10 @@ class Input:
         self._map_in = copy.deepcopy(br)
         self.dtime = self.map.date
         self.br = self.map.data
-        self.brout = brout
-        self.br1 = br1
+        if isinstance(br_outer, sunpy.map.GenericMap):
+            self.br_outer = br_outer.data
+        else:
+            self.br_outer = br_outer
 
         # Force some nice defaults
         self._map_in.plot_settings['cmap'] = 'RdBu'

--- a/pfsspy/input.py
+++ b/pfsspy/input.py
@@ -31,7 +31,7 @@ class Input:
     :math:`s = \cos (\theta)`. See `pfsspy.grid` for more
     information on the coordinate system.
     """
-    def __init__(self, br, nr, rss, brout="radial"):
+    def __init__(self, br, nr, rss, brout="radial", br1=[]):
         if not isinstance(br, sunpy.map.GenericMap):
             raise ValueError('br must be a sunpy Map')
         if np.any(~np.isfinite(br.data)):
@@ -46,6 +46,7 @@ class Input:
         self.dtime = self.map.date
         self.br = self.map.data
         self.brout = brout
+        self.br1 = br1
 
         # Force some nice defaults
         self._map_in.plot_settings['cmap'] = 'RdBu'

--- a/pfsspy/pfss.py
+++ b/pfsspy/pfss.py
@@ -127,8 +127,10 @@ def pfss(input):
     brt = np.fft.rfft(br0, axis=1)
     brt = brt.astype(np.complex128)
 
-    brt1 = np.fft.rfft(br1, axis=1)
-    brt1 = brt1.astype(np.complex128)
+    brt1 = None
+    if brout == "br":
+        brt1 = np.fft.rfft(br1, axis=1)
+        brt1 = brt1.astype(np.complex128)
 
     # Prepare tridiagonal matrix:
     # - create off-diagonal part of the matrix:

--- a/pfsspy/pfss.py
+++ b/pfsspy/pfss.py
@@ -17,7 +17,7 @@ def _eigh(A):
     return np.linalg.eigh(A)
 
 
-def _compute_r_term(m, k, ns, Q, brt, lam, ffm, nr, ffp, psi, psir, rss, brt1, brout):
+def _compute_r_term(m, k, ns, Q, brt, lam, ffm, nr, ffp, psi, psir, rss, brout, brt1):
     for l in range(ns):
         # Ignore the l=0 and m=0 term; for a globally divergence free field
         # this term is zero anyway, but numerically it may be small which
@@ -35,7 +35,7 @@ def _compute_r_term(m, k, ns, Q, brt, lam, ffm, nr, ffp, psi, psir, rss, brt1, b
             clm = ratio * dlm
 
         if brout == "closed":
-            cdlm1 = np.dot(Q[:, l], brt1[:, m])/lam[l]*rss**2
+            cdlm1 = np.dot(Q[:, l], brt1[:, m]) / lam[l] * rss**2
             clm = (cdlm1 - ffm[l]**nr * cdlm) / (ffp[l]**nr - ffm[l]**nr)
             dlm = (cdlm1 - ffp[l]**nr * cdlm) / (ffm[l]**nr - ffp[l]**nr)
 
@@ -113,6 +113,7 @@ def pfss(input):
     sc = input.grid.sc
 
     brout = input.brout
+    br1 = input.br1
 
     k = np.linspace(0, nr, nr + 1)
 
@@ -126,8 +127,8 @@ def pfss(input):
     brt = np.fft.rfft(br0, axis=1)
     brt = brt.astype(np.complex128)
 
-    brt1 = np.fft.rfft(0*br0, axis=1)
-    # brt1 = brt1.astype(np.complex128)
+    brt1 = np.fft.rfft(br1, axis=1)
+    brt1 = brt1.astype(np.complex128)
 
     # Prepare tridiagonal matrix:
     # - create off-diagonal part of the matrix:
@@ -159,7 +160,7 @@ def pfss(input):
         ffm = e1 / ffp
 
         # - compute radial term for each l (for this m):
-        psi, psir = _compute_r_term(m, k, ns, Q, brt, lam, ffm, nr, ffp, psi, psir, rss, brt1, brout)
+        psi, psir = _compute_r_term(m, k, ns, Q, brt, lam, ffm, nr, ffp, psi, psir, rss, brout, brt1)
 
         if (m > 0):
             psi[:, :, nphi - m] = np.conj(psi[:, :, m])

--- a/pfsspy/pfss.py
+++ b/pfsspy/pfss.py
@@ -34,7 +34,7 @@ def _compute_r_term(m, k, ns, Q, brt, lam, ffm, nr, ffp, psi, psir, rss, brout, 
             dlm = cdlm / (1.0 + ratio)
             clm = ratio * dlm
 
-        if brout == "closed":
+        if brout == "br":
             cdlm1 = np.dot(Q[:, l], brt1[:, m]) / lam[l] * rss**2
             clm = (cdlm1 - ffm[l]**nr * cdlm) / (ffp[l]**nr - ffm[l]**nr)
             dlm = (cdlm1 - ffp[l]**nr * cdlm) / (ffm[l]**nr - ffp[l]**nr)


### PR DESCRIPTION
This PR adds the option to solve using an arbitrary map for the outer boundary condition on `br`, a functionality which is already present in Anthony Yeates's [original code](https://github.com/antyeates1983/pfss/blob/a8e1db39b8712a616ad5d11c6b92b8605bee02ae/pfss.py#L110-L115). Here, it is implemented in a similar manner. (For mathematical details, see the text following Equation 24 in the ["Notes on the Numerical Methods" document](https://github.com/dstansby/pfsspy/blob/b22eb10c47a98e44bd9b90be101a9b5c0929e269/doc/source/manual/numerical_methods.pdf).)

An example use would be as follows:
```
import sunpy.map

gong_fname = get_gong_map()
gong_map = sunpy.map.Map(gong_fname)
nrho = 16
rss = 2.5
pfss_in = pfsspy.Input(gong_map, nrho, rss, brout="closed", br1=gong_map.data)
pfss_out = pfsspy.pfss(pfss_in)
```
This should give a solution where the outer boundary condition is the same source field as the inner. Alternatively, allowing `br1=0*gong_map.data` should give an outer boundary condition where the source field Br is always zero. This latter example may be useful to some, e.g., [Caplan et al 2021](https://doi.org/10.3847/1538-4357/abfd2f).